### PR TITLE
Package name filtering to remove "-development" patterns

### DIFF
--- a/src/sdk-manage
+++ b/src/sdk-manage
@@ -140,7 +140,9 @@ t_zypper() {
 
 get_develpkgs() {
     t_zypper search -- -devel 2>&1 | sed '0,/---------/d' | while IFS='| ' read installed pkg dummy; do
-	echo "${pkg},${installed}"
+	if [[ ${pkg%-devel} != ${pkg} ]]; then
+		echo "${pkg},${installed}"
+	fi
     done 
     return ${PIPESTATUS[0]}
 }


### PR DESCRIPTION
Signed-off-by: Tom Swindell t.swindell@rubyx.co.uk
