### PR TITLE
Mount /var/run/resolvconf under /parentroot/run

### DIFF
--- a/src/mer-sdk-chroot
+++ b/src/mer-sdk-chroot
@@ -166,6 +166,7 @@ prepare_mountpoints() {
     mount_bind /dev/shm
     mount_bind /var/lib/dbus
     mount_bind /var/run/dbus
+    mount_bind /var/run/resolvconf
 
     if [[ $bind_mount_root == "yes" ]] ; then
 	echo "Mounting / as /parentroot"


### PR DESCRIPTION
Without this resolving names didn't work and /etc/resolv.conf -> /parentroot/run/resolvconf/resolv.conf link doesn't actually point to anywhere.
