### PR TITLE
[mer-bash-setup] Set debian_chroot

### DIFF
--- a/src/mer-bash-setup
+++ b/src/mer-bash-setup
@@ -2,6 +2,9 @@
 export MERSDK=1
 [[ -e /etc/profile ]] && . /etc/profile
 
+# Many distributions automatically include this in PS1 when set
+: ${debian_chroot:=MerSDK}
+
 if [[ -e ~/.bash_profile ]] ; then
    . ~/.bash_profile
 elif [[ -e ~/.bash_login ]] ; then


### PR DESCRIPTION
Fixes MER#675

Done a more compact way. A more common/sophisticated way would be to
initialize the variable in /etc/bashrc (part of mer-core/setup) from the
content of /etc/debian_chroot fle and add /etc/debian_chroot here.

Signed-off-by: Martin Kampas martin.kampas@tieto.com
