### PR TITLE
[mer-sdk-chroot] Properly unshare mount namespace

### DIFF
--- a/src/mer-sdk-chroot
+++ b/src/mer-sdk-chroot
@@ -78,6 +78,11 @@ if cmp -s /proc/$PPID/mountinfo /proc/self/mountinfo; then
     exit 1
 fi
 
+# Make sure that mountpoints in the new namespace are really unshared from the
+# parental namespace. See unshare(1).
+# This prevents mounts in the sdk from appearing in the parent fs.
+mount --make-rslave /
+
 # Use the SUDO value if present
 user=$SUDO_USER || true;
 
@@ -126,12 +131,6 @@ if [[ ! -f ${sdkroot}/etc/MerSDK ]] ; then
     exit 1
 fi
 
-sdkparent="$(df -P "$sdkroot/" | tail -1 | awk '{print $NF}')"
-if [ -z  "$sdkparent" ] ; then
-    echo "Unable to determine mount mouint of filesystem containing \"$sdkroot\""
-    exit 1
-fi
-
 if [[ -z $user ]] ; then
     echo "$0 expects to be run as root using sudo"
     echo "User could not be obtained from \$SUDO_USER, if running as root,"
@@ -157,10 +156,6 @@ mount_bind() {
     mount --bind $1 ${sdkroot}$1
 }
 prepare_mountpoints() {
-    # Make parent mountpoint not shared with parent namespace
-    # This prevents mounts in the sdk from appearing in the parent fs
-    mount --make-slave "$sdkparent/"
-
     echo "Mounting system directories..."
     mount_bind /proc
     mount_bind /proc/sys/fs/binfmt_misc


### PR DESCRIPTION
Fixes MER#717

Signed-off-by: Martin Kampas martin.kampas@tieto.com
