### PR TITLE
[mer-sdk-chroot] Fix for users using a different shell than bash

### DIFF
--- a/src/mer-sdk-chroot
+++ b/src/mer-sdk-chroot
@@ -185,9 +185,11 @@ prepare_mountpoints() {
 prepare_user() {
     # remove mer user if present
     sed -i -e "/^mer:/d" ${sdkroot}/etc/passwd
-    # getent is probably best for user data
+    # Remove ${user} if present
     sed -i -e "/^${user}:/d" ${sdkroot}/etc/passwd
-    getent passwd $user >> ${sdkroot}/etc/passwd
+    # Use getent to get ${user}'s record from /etc/passwd
+    # Use awk to make sure the shell is set to /bin/bash
+    getent passwd $user | awk 'BEGIN { FS = ":" } { OFS = ":"} { $7="/bin/bash"; print }'>> ${sdkroot}/etc/passwd
     group=$(getent passwd $user | cut -f4 -d:)
     sed -i -e "/^[^:]*:[^:]*:${group}:/d" ${sdkroot}/etc/group
     getent group $group >> ${sdkroot}/etc/group


### PR DESCRIPTION
Uses `awk` to replace the shell value in `/etc/passwd` with `/bin/bash`